### PR TITLE
refactor: Updated the recipe to have multiple outputs

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,64 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 schema_version: 1
 
 context:
-  version: 1.11.0
-
-package:
   name: hpx
-  version: ${{ version }}
+  version: 1.11.0
+  build_number: 7
 
 source:
   url: https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 01ec47228a2253b41e318bb09c83325a75021eb6ef3262400fbda30ac7389279
 
 build:
-  number: 6
+  number: ${{ build_number }}
 
-requirements:
-  build:
-    - ${{ compiler('cxx') }}
-    - ${{ stdlib("c") }}
-    - cmake
-    - if: win
-      then: git
-    - if: not win
-      then: ninja
-  host:
-    - asio
-    - libboost-devel
-    - if: not win
-      then: gperftools
-    - libhwloc
-    - if: win
-      then: mimalloc
-    - python
-  run:
-    # Packages needed for downstream packages that use HPX at:
-    # - build-time: headers, libraries
-    # - runtime: shared libraries, interpreter (for hpxrun.py)
-    # Only list packages whose meta.yaml doesn't contain a run_exports already
-    - asio
-    - libboost-devel
-    - if: not win
-      then: gperftools
-    - python
-  run_exports:
-    weak:
-      - ${{ pin_subpackage("hpx", upper_bound="x.x") }}
-
-tests:
-  - files:
-      recipe:
-        - test/CMakeLists.txt
-        - test/hello_hpx.cpp
+outputs:
+  - package:
+      name: ${{ name }}
+      version: ${{ version }}
     requirements:
-      run:
+      build:
         - ${{ compiler('cxx') }}
+        - ${{ stdlib("c") }}
         - cmake
+        - if: win
+          then: git
         - if: not win
           then: ninja
-    script:
-      - hpxrun.py --help
+      host:
+        - asio
+        - libboost-devel
+        - if: not win
+          then: gperftools
+        - libhwloc
+        - if: win
+          then: mimalloc
+        - python
+      run:
+        # Packages needed for downstream packages that use HPX at:
+        # - build-time: headers, libraries
+        # - runtime: shared libraries, interpreter (for hpxrun.py)
+        # Only list packages whose meta.yaml doesn't contain a run_exports already
+        - asio
+        - libboost-devel
+        - if: not win
+          then: gperftools
+        - python
+      run_exports:
+        weak:
+          - ${{ pin_subpackage("hpx", upper_bound="x.x") }}
+
+    tests:
+      - files:
+          recipe:
+            - test/CMakeLists.txt
+            - test/hello_hpx.cpp
+        requirements:
+          run:
+            - ${{ compiler('cxx') }}
+            - cmake
+            - if: not win
+              then: ninja
+        script:
+          - hpxrun.py --help
 
 about:
   summary: The C++ Standard Library for Parallelism and Concurrency

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  name: "hpx"
+  name: hpx
   version: 1.11.0
   build_number: 7
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,9 +2,13 @@
 schema_version: 1
 
 context:
-  name: hpx
+  name: "hpx"
   version: 1.11.0
   build_number: 7
+
+recipe:
+  name: ${{ name }}
+  version: ${{ version }}
 
 source:
   url: https://github.com/STEllAR-GROUP/hpx/archive/refs/tags/v${{ version }}.tar.gz


### PR DESCRIPTION
Updated the recipe to be a "Complex Recipe", meaning that it can output multiple packages in preparation of creating variety of packages as mentioned in
issue https://github.com/conda-forge/hpx-feedstock/issues/10, and others.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
