### PR TITLE
build: Add hpx-system conda package as another output

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-hpx-green.svg)](https://anaconda.org/conda-forge/hpx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hpx.svg)](https://anaconda.org/conda-forge/hpx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hpx.svg)](https://anaconda.org/conda-forge/hpx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hpx.svg)](https://anaconda.org/conda-forge/hpx) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-hpx--system-green.svg)](https://anaconda.org/conda-forge/hpx-system) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hpx-system.svg)](https://anaconda.org/conda-forge/hpx-system) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hpx-system.svg)](https://anaconda.org/conda-forge/hpx-system) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hpx-system.svg)](https://anaconda.org/conda-forge/hpx-system) |
 
 Installing hpx
 ==============
@@ -200,16 +201,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `hpx` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `hpx, hpx-system` can be installed with `conda`:
 
 ```
-conda install hpx
+conda install hpx hpx-system
 ```
 
 or with `mamba`:
 
 ```
-mamba install hpx
+mamba install hpx hpx-system
 ```
 
 It is possible to list all of the versions of `hpx` available on your platform with `conda`:

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -2,12 +2,14 @@ mkdir build
 pushd build
 if errorlevel 1 exit /b 1
 
+if not defined malloc set malloc=mimalloc
+
 cmake ^
     %CMAKE_ARGS% ^
     -D Python_EXECUTABLE="%PYTHON%" ^
     -D CMAKE_INSTALL_LIBDIR=lib ^
     -D HPX_WITH_EXAMPLES=FALSE ^
-    -D HPX_WITH_MALLOC="mimalloc" ^
+    -D HPX_WITH_MALLOC="%malloc%" ^
     -D HPX_WITH_NETWORKING=FALSE ^
     -D HPX_WITH_TESTS=FALSE ^
     ..

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,7 @@ cmake \
     -D CMAKE_INSTALL_LIBDIR=lib \
     -D Python_EXECUTABLE="$PYTHON" \
     -D HPX_WITH_EXAMPLES=FALSE \
-    -D HPX_WITH_MALLOC="tcmalloc" \
+    -D HPX_WITH_MALLOC="${malloc:-tcmalloc}" \
     -D HPX_WITH_NETWORKING=FALSE \
     -D HPX_WITH_TESTS=FALSE \
     ..

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -67,6 +67,60 @@ outputs:
         script:
           - hpxrun.py --help
 
+  - package:
+      name: ${{ name }}-system
+      version: ${{ version }}
+    build:
+      script:
+        file: ${{ "build.sh" if unix else "build.bat" }}
+        env: 
+          malloc: system
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib("c") }}
+        - cmake
+        - if: win
+          then: git
+        - if: not win
+          then: ninja
+      host:
+        - asio
+        - libboost-devel
+        - if: not win
+          then: gperftools
+        - libhwloc
+        - if: win
+          then: mimalloc
+        - python
+      run:
+        # Packages needed for downstream packages that use HPX at:
+        # - build-time: headers, libraries
+        # - runtime: shared libraries, interpreter (for hpxrun.py)
+        # Only list packages whose meta.yaml doesn't contain a run_exports already
+        - asio
+        - libboost-devel
+        - if: not win
+          then: gperftools
+        - python
+      run_exports:
+        weak:
+          - ${{ pin_subpackage("hpx-system", upper_bound="x.x") }}
+
+    tests:
+      - files:
+          recipe:
+            - test/CMakeLists.txt
+            - test/hello_hpx.cpp
+        requirements:
+          run:
+            - ${{ compiler('cxx') }}
+            - cmake
+            - if: not win
+              then: ninja
+        script:
+          - hpxrun.py --help
+
 about:
   summary: The C++ Standard Library for Parallelism and Concurrency
   description: |

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 context:
   name: hpx
   version: 1.11.0
-  build_number: 7
+  build_number: 8
 
 recipe:
   name: ${{ name }}


### PR DESCRIPTION
This PR is a follow up to https://github.com/conda-forge/hpx-feedstock/pull/37. Instead of complex and clunky build variant, hpx with the `system` allocator now is a separate output. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
