### PR TITLE
build: Add HPX build variant setup

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,24 +8,44 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_python3.10.____cpython:
-        CONFIG: linux_64_python3.10.____cpython
+      linux_64_mallocsystempython3.10.____cpython:
+        CONFIG: linux_64_mallocsystempython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_python3.11.____cpython:
-        CONFIG: linux_64_python3.11.____cpython
+      linux_64_mallocsystempython3.11.____cpython:
+        CONFIG: linux_64_mallocsystempython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_python3.12.____cpython:
-        CONFIG: linux_64_python3.12.____cpython
+      linux_64_mallocsystempython3.12.____cpython:
+        CONFIG: linux_64_mallocsystempython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_python3.13.____cp313:
-        CONFIG: linux_64_python3.13.____cp313
+      linux_64_mallocsystempython3.13.____cp313:
+        CONFIG: linux_64_mallocsystempython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_python3.9.____cpython:
-        CONFIG: linux_64_python3.9.____cpython
+      linux_64_mallocsystempython3.9.____cpython:
+        CONFIG: linux_64_mallocsystempython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_malloctcmallocpython3.10.____cpython:
+        CONFIG: linux_64_malloctcmallocpython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_malloctcmallocpython3.11.____cpython:
+        CONFIG: linux_64_malloctcmallocpython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_malloctcmallocpython3.12.____cpython:
+        CONFIG: linux_64_malloctcmallocpython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_malloctcmallocpython3.13.____cp313:
+        CONFIG: linux_64_malloctcmallocpython3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_malloctcmallocpython3.9.____cpython:
+        CONFIG: linux_64_malloctcmallocpython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,35 +8,65 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_python3.10.____cpython:
-        CONFIG: osx_64_python3.10.____cpython
+      osx_64_mallocsystempython3.10.____cpython:
+        CONFIG: osx_64_mallocsystempython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.11.____cpython:
-        CONFIG: osx_64_python3.11.____cpython
+      osx_64_mallocsystempython3.11.____cpython:
+        CONFIG: osx_64_mallocsystempython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.12.____cpython:
-        CONFIG: osx_64_python3.12.____cpython
+      osx_64_mallocsystempython3.12.____cpython:
+        CONFIG: osx_64_mallocsystempython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.13.____cp313:
-        CONFIG: osx_64_python3.13.____cp313
+      osx_64_mallocsystempython3.13.____cp313:
+        CONFIG: osx_64_mallocsystempython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-      osx_64_python3.9.____cpython:
-        CONFIG: osx_64_python3.9.____cpython
+      osx_64_mallocsystempython3.9.____cpython:
+        CONFIG: osx_64_mallocsystempython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_python3.10.____cpython:
-        CONFIG: osx_arm64_python3.10.____cpython
+      osx_64_malloctcmallocpython3.10.____cpython:
+        CONFIG: osx_64_malloctcmallocpython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_python3.11.____cpython:
-        CONFIG: osx_arm64_python3.11.____cpython
+      osx_64_malloctcmallocpython3.11.____cpython:
+        CONFIG: osx_64_malloctcmallocpython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_python3.12.____cpython:
-        CONFIG: osx_arm64_python3.12.____cpython
+      osx_64_malloctcmallocpython3.12.____cpython:
+        CONFIG: osx_64_malloctcmallocpython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_python3.13.____cp313:
-        CONFIG: osx_arm64_python3.13.____cp313
+      osx_64_malloctcmallocpython3.13.____cp313:
+        CONFIG: osx_64_malloctcmallocpython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_python3.9.____cpython:
-        CONFIG: osx_arm64_python3.9.____cpython
+      osx_64_malloctcmallocpython3.9.____cpython:
+        CONFIG: osx_64_malloctcmallocpython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mallocsystempython3.10.____cpython:
+        CONFIG: osx_arm64_mallocsystempython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mallocsystempython3.11.____cpython:
+        CONFIG: osx_arm64_mallocsystempython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mallocsystempython3.12.____cpython:
+        CONFIG: osx_arm64_mallocsystempython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mallocsystempython3.13.____cp313:
+        CONFIG: osx_arm64_mallocsystempython3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mallocsystempython3.9.____cpython:
+        CONFIG: osx_arm64_mallocsystempython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_malloctcmallocpython3.10.____cpython:
+        CONFIG: osx_arm64_malloctcmallocpython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_malloctcmallocpython3.11.____cpython:
+        CONFIG: osx_arm64_malloctcmallocpython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_malloctcmallocpython3.12.____cpython:
+        CONFIG: osx_arm64_malloctcmallocpython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_malloctcmallocpython3.13.____cp313:
+        CONFIG: osx_arm64_malloctcmallocpython3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_malloctcmallocpython3.9.____cpython:
+        CONFIG: osx_arm64_malloctcmallocpython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,20 +8,35 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_python3.10.____cpython:
-        CONFIG: win_64_python3.10.____cpython
+      win_64_mallocmimallocpython3.10.____cpython:
+        CONFIG: win_64_mallocmimallocpython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-      win_64_python3.11.____cpython:
-        CONFIG: win_64_python3.11.____cpython
+      win_64_mallocmimallocpython3.11.____cpython:
+        CONFIG: win_64_mallocmimallocpython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      win_64_python3.12.____cpython:
-        CONFIG: win_64_python3.12.____cpython
+      win_64_mallocmimallocpython3.12.____cpython:
+        CONFIG: win_64_mallocmimallocpython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-      win_64_python3.13.____cp313:
-        CONFIG: win_64_python3.13.____cp313
+      win_64_mallocmimallocpython3.13.____cp313:
+        CONFIG: win_64_mallocmimallocpython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-      win_64_python3.9.____cpython:
-        CONFIG: win_64_python3.9.____cpython
+      win_64_mallocmimallocpython3.9.____cpython:
+        CONFIG: win_64_mallocmimallocpython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_mallocsystempython3.10.____cpython:
+        CONFIG: win_64_mallocsystempython3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_mallocsystempython3.11.____cpython:
+        CONFIG: win_64_mallocsystempython3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_mallocsystempython3.12.____cpython:
+        CONFIG: win_64_mallocsystempython3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_mallocsystempython3.13.____cp313:
+        CONFIG: win_64_mallocsystempython3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+      win_64_mallocsystempython3.9.____cpython:
+        CONFIG: win_64_mallocsystempython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_mallocsystempython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_mallocsystempython3.10.____cpython.yaml
@@ -1,0 +1,30 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_mallocsystempython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_mallocsystempython3.11.____cpython.yaml
@@ -1,0 +1,30 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_mallocsystempython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_mallocsystempython3.12.____cpython.yaml
@@ -1,0 +1,30 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_mallocsystempython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_mallocsystempython3.13.____cp313.yaml
@@ -1,30 +1,30 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
-macos_machine:
-- x86_64-apple-darwin13.4.0
+malloc:
+- system
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_64_mallocsystempython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mallocsystempython3.9.____cpython.yaml
@@ -1,30 +1,30 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
-macos_machine:
-- arm64-apple-darwin20.0.0
+malloc:
+- system
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-arm64
+- linux-64

--- a/.ci_support/linux_64_malloctcmallocpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_malloctcmallocpython3.10.____cpython.yaml
@@ -18,6 +18,8 @@ libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_malloctcmallocpython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_malloctcmallocpython3.11.____cpython.yaml
@@ -1,0 +1,30 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- tcmalloc
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_malloctcmallocpython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_malloctcmallocpython3.12.____cpython.yaml
@@ -1,0 +1,30 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- tcmalloc
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_malloctcmallocpython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_malloctcmallocpython3.13.____cp313.yaml
@@ -1,0 +1,30 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- tcmalloc
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_malloctcmallocpython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_malloctcmallocpython3.9.____cpython.yaml
@@ -1,30 +1,30 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
-macos_machine:
-- x86_64-apple-darwin13.4.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.9.* *_cpython
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/osx_64_mallocsystempython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_mallocsystempython3.10.____cpython.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_mallocsystempython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_mallocsystempython3.11.____cpython.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_mallocsystempython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_mallocsystempython3.12.____cpython.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_mallocsystempython3.13.____cp313.yaml
+++ b/.ci_support/osx_64_mallocsystempython3.13.____cp313.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_mallocsystempython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mallocsystempython3.9.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,12 +19,14 @@ libboost_devel:
 libhwloc:
 - 2.12.1
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
+malloc:
+- system
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64

--- a/.ci_support/osx_64_malloctcmallocpython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_malloctcmallocpython3.10.____cpython.yaml
@@ -1,28 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.10.* *_cpython
 target_platform:
-- linux-64
+- osx-64

--- a/.ci_support/osx_64_malloctcmallocpython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_malloctcmallocpython3.11.____cpython.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- tcmalloc
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_malloctcmallocpython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_malloctcmallocpython3.12.____cpython.yaml
@@ -20,11 +20,13 @@ libhwloc:
 - 2.12.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_malloctcmallocpython3.13.____cp313.yaml
+++ b/.ci_support/osx_64_malloctcmallocpython3.13.____cp313.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+malloc:
+- tcmalloc
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_malloctcmallocpython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_malloctcmallocpython3.9.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,12 +19,14 @@ libboost_devel:
 libhwloc:
 - 2.12.1
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.9.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64

--- a/.ci_support/osx_arm64_mallocsystempython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mallocsystempython3.10.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,7 +19,9 @@ libboost_devel:
 libhwloc:
 - 2.12.1
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
+malloc:
+- system
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -27,4 +29,4 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 target_platform:
-- osx-64
+- osx-arm64

--- a/.ci_support/osx_arm64_mallocsystempython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mallocsystempython3.11.____cpython.yaml
@@ -20,11 +20,13 @@ libhwloc:
 - 2.12.1
 macos_machine:
 - arm64-apple-darwin20.0.0
+malloc:
+- system
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_mallocsystempython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_mallocsystempython3.12.____cpython.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mallocsystempython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_mallocsystempython3.13.____cp313.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+malloc:
+- system
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_mallocsystempython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mallocsystempython3.9.____cpython.yaml
@@ -20,11 +20,13 @@ libhwloc:
 - 2.12.1
 macos_machine:
 - arm64-apple-darwin20.0.0
+malloc:
+- system
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - osx-arm64

--- a/.ci_support/osx_arm64_malloctcmallocpython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_malloctcmallocpython3.10.____cpython.yaml
@@ -1,28 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-64
+- osx-arm64

--- a/.ci_support/osx_arm64_malloctcmallocpython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_malloctcmallocpython3.11.____cpython.yaml
@@ -1,0 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+malloc:
+- tcmalloc
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_malloctcmallocpython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_malloctcmallocpython3.12.____cpython.yaml
@@ -1,28 +1,32 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+macos_machine:
+- arm64-apple-darwin20.0.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-64
+- osx-arm64

--- a/.ci_support/osx_arm64_malloctcmallocpython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_malloctcmallocpython3.13.____cp313.yaml
@@ -1,17 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_stdlib:
-- vs
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2022
+- clangxx
+cxx_compiler_version:
+- '19'
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
-mimalloc:
-- 3.1.5
+macos_machine:
+- arm64-apple-darwin20.0.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,4 +29,4 @@ pin_run_as_build:
 python:
 - 3.13.* *_cp313
 target_platform:
-- win-64
+- osx-arm64

--- a/.ci_support/osx_arm64_malloctcmallocpython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_malloctcmallocpython3.9.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,12 +19,14 @@ libboost_devel:
 libhwloc:
 - 2.12.1
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
+malloc:
+- tcmalloc
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-64
+- osx-arm64

--- a/.ci_support/win_64_mallocmimallocpython3.10.____cpython.yaml
+++ b/.ci_support/win_64_mallocmimallocpython3.10.____cpython.yaml
@@ -1,0 +1,24 @@
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- mimalloc
+mimalloc:
+- 3.1.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_mallocmimallocpython3.11.____cpython.yaml
+++ b/.ci_support/win_64_mallocmimallocpython3.11.____cpython.yaml
@@ -1,0 +1,24 @@
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- mimalloc
+mimalloc:
+- 3.1.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_mallocmimallocpython3.12.____cpython.yaml
+++ b/.ci_support/win_64_mallocmimallocpython3.12.____cpython.yaml
@@ -1,0 +1,24 @@
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- mimalloc
+mimalloc:
+- 3.1.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_mallocmimallocpython3.13.____cp313.yaml
+++ b/.ci_support/win_64_mallocmimallocpython3.13.____cp313.yaml
@@ -10,6 +10,8 @@ libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+malloc:
+- mimalloc
 mimalloc:
 - 3.1.5
 pin_run_as_build:
@@ -17,6 +19,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
 - win-64

--- a/.ci_support/win_64_mallocmimallocpython3.9.____cpython.yaml
+++ b/.ci_support/win_64_mallocmimallocpython3.9.____cpython.yaml
@@ -1,28 +1,24 @@
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- vs2022
 libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+malloc:
+- mimalloc
+mimalloc:
+- 3.1.5
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-64
+- win-64

--- a/.ci_support/win_64_mallocsystempython3.10.____cpython.yaml
+++ b/.ci_support/win_64_mallocsystempython3.10.____cpython.yaml
@@ -10,6 +10,8 @@ libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+malloc:
+- system
 mimalloc:
 - 3.1.5
 pin_run_as_build:

--- a/.ci_support/win_64_mallocsystempython3.11.____cpython.yaml
+++ b/.ci_support/win_64_mallocsystempython3.11.____cpython.yaml
@@ -10,6 +10,8 @@ libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+malloc:
+- system
 mimalloc:
 - 3.1.5
 pin_run_as_build:
@@ -17,6 +19,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.11.* *_cpython
 target_platform:
 - win-64

--- a/.ci_support/win_64_mallocsystempython3.12.____cpython.yaml
+++ b/.ci_support/win_64_mallocsystempython3.12.____cpython.yaml
@@ -1,0 +1,24 @@
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- system
+mimalloc:
+- 3.1.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_mallocsystempython3.13.____cp313.yaml
+++ b/.ci_support/win_64_mallocsystempython3.13.____cp313.yaml
@@ -1,0 +1,24 @@
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+libboost_devel:
+- '1.88'
+libhwloc:
+- 2.12.1
+malloc:
+- system
+mimalloc:
+- 3.1.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- win-64

--- a/.ci_support/win_64_mallocsystempython3.9.____cpython.yaml
+++ b/.ci_support/win_64_mallocsystempython3.9.____cpython.yaml
@@ -10,6 +10,8 @@ libboost_devel:
 - '1.88'
 libhwloc:
 - 2.12.1
+malloc:
+- system
 mimalloc:
 - 3.1.5
 pin_run_as_build:

--- a/README.md
+++ b/README.md
@@ -36,143 +36,283 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_python3.10.____cpython</td>
+              <td>linux_64_mallocsystempython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mallocsystempython3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.11.____cpython</td>
+              <td>linux_64_mallocsystempython3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mallocsystempython3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.12.____cpython</td>
+              <td>linux_64_mallocsystempython3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mallocsystempython3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.13.____cp313</td>
+              <td>linux_64_mallocsystempython3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mallocsystempython3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_python3.9.____cpython</td>
+              <td>linux_64_mallocsystempython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mallocsystempython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.10.____cpython</td>
+              <td>linux_64_malloctcmallocpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_malloctcmallocpython3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.11.____cpython</td>
+              <td>linux_64_malloctcmallocpython3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_malloctcmallocpython3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.12.____cpython</td>
+              <td>linux_64_malloctcmallocpython3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_malloctcmallocpython3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.13.____cp313</td>
+              <td>linux_64_malloctcmallocpython3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_malloctcmallocpython3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_python3.9.____cpython</td>
+              <td>linux_64_malloctcmallocpython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_malloctcmallocpython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.10.____cpython</td>
+              <td>osx_64_mallocsystempython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mallocsystempython3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.11.____cpython</td>
+              <td>osx_64_mallocsystempython3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mallocsystempython3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.12.____cpython</td>
+              <td>osx_64_mallocsystempython3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mallocsystempython3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.13.____cp313</td>
+              <td>osx_64_mallocsystempython3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mallocsystempython3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_python3.9.____cpython</td>
+              <td>osx_64_mallocsystempython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mallocsystempython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python3.10.____cpython</td>
+              <td>osx_64_malloctcmallocpython3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_malloctcmallocpython3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python3.11.____cpython</td>
+              <td>osx_64_malloctcmallocpython3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_malloctcmallocpython3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python3.12.____cpython</td>
+              <td>osx_64_malloctcmallocpython3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_malloctcmallocpython3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python3.13.____cp313</td>
+              <td>osx_64_malloctcmallocpython3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_malloctcmallocpython3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_python3.9.____cpython</td>
+              <td>osx_64_malloctcmallocpython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_malloctcmallocpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mallocsystempython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mallocsystempython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mallocsystempython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mallocsystempython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mallocsystempython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mallocsystempython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mallocsystempython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mallocsystempython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mallocsystempython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mallocsystempython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_malloctcmallocpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_malloctcmallocpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_malloctcmallocpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_malloctcmallocpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_malloctcmallocpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_malloctcmallocpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_malloctcmallocpython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_malloctcmallocpython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_malloctcmallocpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_malloctcmallocpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocmimallocpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocmimallocpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocmimallocpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocmimallocpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocmimallocpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocmimallocpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocmimallocpython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocmimallocpython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocmimallocpython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocmimallocpython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocsystempython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocsystempython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocsystempython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocsystempython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocsystempython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocsystempython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocsystempython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocsystempython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_mallocsystempython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17801&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hpx-feedstock?branchName=main&jobName=win&configuration=win%20win_64_mallocsystempython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,126 +25,246 @@ description = "List contents of all packages found in rattler-build build direct
 [tasks.build]
 cmd = "rattler-build build --recipe recipe"
 description = "Build hpx-feedstock directly (without setup scripts), no particular variant specified"
-[tasks."build-linux_64_python3.10.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
-description = "Build hpx-feedstock with variant linux_64_python3.10.____cpython directly (without setup scripts)"
-[tasks."inspect-linux_64_python3.10.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant linux_64_python3.10.____cpython"
-[tasks."build-linux_64_python3.11.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
-description = "Build hpx-feedstock with variant linux_64_python3.11.____cpython directly (without setup scripts)"
-[tasks."inspect-linux_64_python3.11.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant linux_64_python3.11.____cpython"
-[tasks."build-linux_64_python3.12.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
-description = "Build hpx-feedstock with variant linux_64_python3.12.____cpython directly (without setup scripts)"
-[tasks."inspect-linux_64_python3.12.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant linux_64_python3.12.____cpython"
-[tasks."build-linux_64_python3.13.____cp313"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
-description = "Build hpx-feedstock with variant linux_64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."inspect-linux_64_python3.13.____cp313"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
-description = "List contents of hpx-feedstock packages built for variant linux_64_python3.13.____cp313"
-[tasks."build-linux_64_python3.9.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.9.____cpython.yaml"
-description = "Build hpx-feedstock with variant linux_64_python3.9.____cpython directly (without setup scripts)"
-[tasks."inspect-linux_64_python3.9.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.9.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant linux_64_python3.9.____cpython"
-[tasks."build-osx_64_python3.10.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_64_python3.10.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_64_python3.10.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.10.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_64_python3.10.____cpython"
-[tasks."build-osx_64_python3.11.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_64_python3.11.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_64_python3.11.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_64_python3.11.____cpython"
-[tasks."build-osx_64_python3.12.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_64_python3.12.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_64_python3.12.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_64_python3.12.____cpython"
-[tasks."build-osx_64_python3.13.____cp313"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
-description = "Build hpx-feedstock with variant osx_64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."inspect-osx_64_python3.13.____cp313"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_64_python3.13.____cp313"
-[tasks."build-osx_64_python3.9.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.9.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_64_python3.9.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_64_python3.9.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.9.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_64_python3.9.____cpython"
-[tasks."build-osx_arm64_python3.10.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_arm64_python3.10.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_arm64_python3.10.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.10.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_arm64_python3.10.____cpython"
-[tasks."build-osx_arm64_python3.11.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_arm64_python3.11.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_arm64_python3.11.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_arm64_python3.11.____cpython"
-[tasks."build-osx_arm64_python3.12.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_arm64_python3.12.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_arm64_python3.12.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.12.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_arm64_python3.12.____cpython"
-[tasks."build-osx_arm64_python3.13.____cp313"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
-description = "Build hpx-feedstock with variant osx_arm64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."inspect-osx_arm64_python3.13.____cp313"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_arm64_python3.13.____cp313"
-[tasks."build-osx_arm64_python3.9.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.9.____cpython.yaml"
-description = "Build hpx-feedstock with variant osx_arm64_python3.9.____cpython directly (without setup scripts)"
-[tasks."inspect-osx_arm64_python3.9.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.9.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant osx_arm64_python3.9.____cpython"
-[tasks."build-win_64_python3.10.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.10.____cpython.yaml"
-description = "Build hpx-feedstock with variant win_64_python3.10.____cpython directly (without setup scripts)"
-[tasks."inspect-win_64_python3.10.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.10.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant win_64_python3.10.____cpython"
-[tasks."build-win_64_python3.11.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.11.____cpython.yaml"
-description = "Build hpx-feedstock with variant win_64_python3.11.____cpython directly (without setup scripts)"
-[tasks."inspect-win_64_python3.11.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.11.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant win_64_python3.11.____cpython"
-[tasks."build-win_64_python3.12.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.12.____cpython.yaml"
-description = "Build hpx-feedstock with variant win_64_python3.12.____cpython directly (without setup scripts)"
-[tasks."inspect-win_64_python3.12.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.12.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant win_64_python3.12.____cpython"
-[tasks."build-win_64_python3.13.____cp313"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.13.____cp313.yaml"
-description = "Build hpx-feedstock with variant win_64_python3.13.____cp313 directly (without setup scripts)"
-[tasks."inspect-win_64_python3.13.____cp313"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.13.____cp313.yaml"
-description = "List contents of hpx-feedstock packages built for variant win_64_python3.13.____cp313"
-[tasks."build-win_64_python3.9.____cpython"]
-cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.9.____cpython.yaml"
-description = "Build hpx-feedstock with variant win_64_python3.9.____cpython directly (without setup scripts)"
-[tasks."inspect-win_64_python3.9.____cpython"]
-cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.9.____cpython.yaml"
-description = "List contents of hpx-feedstock packages built for variant win_64_python3.9.____cpython"
+[tasks."build-linux_64_mallocsystempython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_mallocsystempython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_mallocsystempython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_mallocsystempython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_mallocsystempython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_mallocsystempython3.10.____cpython"
+[tasks."build-linux_64_mallocsystempython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_mallocsystempython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_mallocsystempython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_mallocsystempython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_mallocsystempython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_mallocsystempython3.11.____cpython"
+[tasks."build-linux_64_mallocsystempython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_mallocsystempython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_mallocsystempython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_mallocsystempython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_mallocsystempython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_mallocsystempython3.12.____cpython"
+[tasks."build-linux_64_mallocsystempython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_mallocsystempython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant linux_64_mallocsystempython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_64_mallocsystempython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_mallocsystempython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_mallocsystempython3.13.____cp313"
+[tasks."build-linux_64_mallocsystempython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_mallocsystempython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_mallocsystempython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_mallocsystempython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_mallocsystempython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_mallocsystempython3.9.____cpython"
+[tasks."build-linux_64_malloctcmallocpython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_malloctcmallocpython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_malloctcmallocpython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_malloctcmallocpython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_malloctcmallocpython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_malloctcmallocpython3.10.____cpython"
+[tasks."build-linux_64_malloctcmallocpython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_malloctcmallocpython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_malloctcmallocpython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_malloctcmallocpython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_malloctcmallocpython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_malloctcmallocpython3.11.____cpython"
+[tasks."build-linux_64_malloctcmallocpython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_malloctcmallocpython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_malloctcmallocpython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_malloctcmallocpython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_malloctcmallocpython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_malloctcmallocpython3.12.____cpython"
+[tasks."build-linux_64_malloctcmallocpython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_malloctcmallocpython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant linux_64_malloctcmallocpython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_64_malloctcmallocpython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_malloctcmallocpython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_malloctcmallocpython3.13.____cp313"
+[tasks."build-linux_64_malloctcmallocpython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_malloctcmallocpython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant linux_64_malloctcmallocpython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_64_malloctcmallocpython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_malloctcmallocpython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant linux_64_malloctcmallocpython3.9.____cpython"
+[tasks."build-osx_64_mallocsystempython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_mallocsystempython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_mallocsystempython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_mallocsystempython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_mallocsystempython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_mallocsystempython3.10.____cpython"
+[tasks."build-osx_64_mallocsystempython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_mallocsystempython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_mallocsystempython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_mallocsystempython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_mallocsystempython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_mallocsystempython3.11.____cpython"
+[tasks."build-osx_64_mallocsystempython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_mallocsystempython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_mallocsystempython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_mallocsystempython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_mallocsystempython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_mallocsystempython3.12.____cpython"
+[tasks."build-osx_64_mallocsystempython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_mallocsystempython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant osx_64_mallocsystempython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-osx_64_mallocsystempython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_mallocsystempython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_mallocsystempython3.13.____cp313"
+[tasks."build-osx_64_mallocsystempython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_mallocsystempython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_mallocsystempython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_mallocsystempython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_mallocsystempython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_mallocsystempython3.9.____cpython"
+[tasks."build-osx_64_malloctcmallocpython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_malloctcmallocpython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_malloctcmallocpython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_malloctcmallocpython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_malloctcmallocpython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_malloctcmallocpython3.10.____cpython"
+[tasks."build-osx_64_malloctcmallocpython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_malloctcmallocpython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_malloctcmallocpython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_malloctcmallocpython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_malloctcmallocpython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_malloctcmallocpython3.11.____cpython"
+[tasks."build-osx_64_malloctcmallocpython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_malloctcmallocpython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_malloctcmallocpython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_malloctcmallocpython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_malloctcmallocpython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_malloctcmallocpython3.12.____cpython"
+[tasks."build-osx_64_malloctcmallocpython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_malloctcmallocpython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant osx_64_malloctcmallocpython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-osx_64_malloctcmallocpython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_malloctcmallocpython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_malloctcmallocpython3.13.____cp313"
+[tasks."build-osx_64_malloctcmallocpython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_malloctcmallocpython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_64_malloctcmallocpython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_64_malloctcmallocpython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_malloctcmallocpython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_64_malloctcmallocpython3.9.____cpython"
+[tasks."build-osx_arm64_mallocsystempython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_mallocsystempython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_mallocsystempython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_mallocsystempython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_mallocsystempython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_mallocsystempython3.10.____cpython"
+[tasks."build-osx_arm64_mallocsystempython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_mallocsystempython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_mallocsystempython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_mallocsystempython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_mallocsystempython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_mallocsystempython3.11.____cpython"
+[tasks."build-osx_arm64_mallocsystempython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_mallocsystempython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_mallocsystempython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_mallocsystempython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_mallocsystempython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_mallocsystempython3.12.____cpython"
+[tasks."build-osx_arm64_mallocsystempython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_mallocsystempython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_mallocsystempython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-osx_arm64_mallocsystempython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_mallocsystempython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_mallocsystempython3.13.____cp313"
+[tasks."build-osx_arm64_mallocsystempython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_mallocsystempython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_mallocsystempython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_mallocsystempython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_mallocsystempython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_mallocsystempython3.9.____cpython"
+[tasks."build-osx_arm64_malloctcmallocpython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_malloctcmallocpython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_malloctcmallocpython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_malloctcmallocpython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_malloctcmallocpython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_malloctcmallocpython3.10.____cpython"
+[tasks."build-osx_arm64_malloctcmallocpython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_malloctcmallocpython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_malloctcmallocpython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_malloctcmallocpython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_malloctcmallocpython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_malloctcmallocpython3.11.____cpython"
+[tasks."build-osx_arm64_malloctcmallocpython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_malloctcmallocpython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_malloctcmallocpython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_malloctcmallocpython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_malloctcmallocpython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_malloctcmallocpython3.12.____cpython"
+[tasks."build-osx_arm64_malloctcmallocpython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_malloctcmallocpython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_malloctcmallocpython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-osx_arm64_malloctcmallocpython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_malloctcmallocpython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_malloctcmallocpython3.13.____cp313"
+[tasks."build-osx_arm64_malloctcmallocpython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_malloctcmallocpython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant osx_arm64_malloctcmallocpython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-osx_arm64_malloctcmallocpython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_malloctcmallocpython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant osx_arm64_malloctcmallocpython3.9.____cpython"
+[tasks."build-win_64_mallocmimallocpython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocmimallocpython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocmimallocpython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocmimallocpython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocmimallocpython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocmimallocpython3.10.____cpython"
+[tasks."build-win_64_mallocmimallocpython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocmimallocpython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocmimallocpython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocmimallocpython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocmimallocpython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocmimallocpython3.11.____cpython"
+[tasks."build-win_64_mallocmimallocpython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocmimallocpython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocmimallocpython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocmimallocpython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocmimallocpython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocmimallocpython3.12.____cpython"
+[tasks."build-win_64_mallocmimallocpython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocmimallocpython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocmimallocpython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-win_64_mallocmimallocpython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocmimallocpython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocmimallocpython3.13.____cp313"
+[tasks."build-win_64_mallocmimallocpython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocmimallocpython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocmimallocpython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocmimallocpython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocmimallocpython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocmimallocpython3.9.____cpython"
+[tasks."build-win_64_mallocsystempython3.10.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocsystempython3.10.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocsystempython3.10.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocsystempython3.10.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocsystempython3.10.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocsystempython3.10.____cpython"
+[tasks."build-win_64_mallocsystempython3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocsystempython3.11.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocsystempython3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocsystempython3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocsystempython3.11.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocsystempython3.11.____cpython"
+[tasks."build-win_64_mallocsystempython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocsystempython3.12.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocsystempython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocsystempython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocsystempython3.12.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocsystempython3.12.____cpython"
+[tasks."build-win_64_mallocsystempython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocsystempython3.13.____cp313.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocsystempython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-win_64_mallocsystempython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocsystempython3.13.____cp313.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocsystempython3.13.____cp313"
+[tasks."build-win_64_mallocsystempython3.9.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_mallocsystempython3.9.____cpython.yaml"
+description = "Build hpx-feedstock with variant win_64_mallocsystempython3.9.____cpython directly (without setup scripts)"
+[tasks."inspect-win_64_mallocsystempython3.9.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_mallocsystempython3.9.____cpython.yaml"
+description = "List contents of hpx-feedstock packages built for variant win_64_mallocsystempython3.9.____cpython"
 
 [feature.smithy.dependencies]
 conda-smithy = "*"

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -2,12 +2,14 @@ mkdir build
 pushd build
 if errorlevel 1 exit /b 1
 
+if not defined malloc set malloc=mimalloc
+
 cmake ^
     %CMAKE_ARGS% ^
     -D Python_EXECUTABLE="%PYTHON%" ^
     -D CMAKE_INSTALL_LIBDIR=lib ^
     -D HPX_WITH_EXAMPLES=FALSE ^
-    -D HPX_WITH_MALLOC="mimalloc" ^
+    -D HPX_WITH_MALLOC="%malloc%" ^
     -D HPX_WITH_NETWORKING=FALSE ^
     -D HPX_WITH_TESTS=FALSE ^
     ..

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,7 @@ cmake \
     -D CMAKE_INSTALL_LIBDIR=lib \
     -D Python_EXECUTABLE="$PYTHON" \
     -D HPX_WITH_EXAMPLES=FALSE \
-    -D HPX_WITH_MALLOC="tcmalloc" \
+    -D HPX_WITH_MALLOC="${malloc:-tcmalloc}" \
     -D HPX_WITH_NETWORKING=FALSE \
     -D HPX_WITH_TESTS=FALSE \
     ..

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+malloc:
+  - mimalloc  # [win]
+  - tcmalloc  # [unix]
+  - system

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -29,6 +29,11 @@ outputs:
   - package:
       name: ${{ name }}
       version: ${{ version }}
+    build:
+      script:
+        file: ${{ "build.sh" if unix else "build.bat" }}
+        env: 
+          malloc: ${{ malloc }}
     requirements:
       build:
         - ${{ compiler('cxx') }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 context:
   name: hpx
   version: 1.11.0
-  build_number: 7
+  build_number: 8
 
 recipe:
   name: ${{ name }}
@@ -15,7 +15,15 @@ source:
   sha256: 01ec47228a2253b41e318bb09c83325a75021eb6ef3262400fbda30ac7389279
 
 build:
+  string: ${{ malloc }}_${{ hash }}_${{ build_number }}
   number: ${{ build_number }}
+  variant:
+    use_keys:
+      # use malloc from the variant config, e.g. to build multiple malloc variants
+      - malloc
+    # this will down-prioritize the system variant versus other variants of the package
+    down_prioritize_variant: ${{ 1 if malloc == "system" else 0 }}
+
 
 outputs:
   - package:


### PR DESCRIPTION
This is another attempt to variant,
this removes the need for a separate package
but create variants for hpx, as
originally was setup in https://github.com/conda-forge/hpx-feedstock/pull/37.

---

Related PRs:
- https://github.com/conda-forge/hpx-feedstock/pull/37
- https://github.com/conda-forge/hpx-feedstock/pull/57
- https://github.com/conda-forge/admin-requests/pull/1615

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
